### PR TITLE
Prevent undefined constant notice

### DIFF
--- a/lib/setup.php
+++ b/lib/setup.php
@@ -6,7 +6,7 @@
 namespace THEMENAME\Setup;
 
 // Define the asset path.
-if ( ! defined( ASSET_PATH ) ) {
+if ( ! defined( 'ASSET_PATH' ) ) {
     define( 'ASSET_PATH', \get_template_directory_uri() . '/dist' );
 }
 


### PR DESCRIPTION
Prevent undefined constant notice by using string to check if ASSET_PATH is defined.