### PR TITLE
Update for documentation and Webpack configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/dist
+/assets/dist
 /node_modules
 /.sass-cache
 /.idea

--- a/README.MD
+++ b/README.MD
@@ -29,9 +29,15 @@ Translations and the theme textdomain are loaded from under the `/lang` director
 
 ## Assets and Webpack
 
-Assets are compiled with [Webpack](https://webpack.github.io/docs/what-is-webpack.html). Use [npm](https://www.npmjs.com/) to install packages and require them in [assets/scripts/main.js](https://github.com/devgeniem/wp-starter-dustpress-theme/blob/master/assets/scripts/main.js) or the themes sass files. The directory under which the assets are build is `/dist`. 
+Assets are compiled with [Webpack](https://webpack.github.io/docs/what-is-webpack.html). Use [npm](https://www.npmjs.com/) to install packages and require JavaScript files in [assets/scripts/main.js](https://github.com/devgeniem/wp-starter-dustpress-theme/blob/master/assets/scripts/main.js) and import Sass files in [assets/styles/main.scss](https://github.com/devgeniem/wp-starter-dustpress-theme/blob/master/assets/styles/main.scss). The directory under which the assets are build is `/dist`. 
 
-The url to be used with the assets is defined in `/lib/setup.php` with the `ASSET_PATH` constant. It points to `https://sitedomain.test/app/themes/themename/dist` by default. This can be overridden for example in `wp-config.php`  to use an external source for theme assets.
+***You should only enqueue files that are under `/dist`!***
+
+The URL to be used with the assets is defined in `/lib/setup.php` with the `ASSET_URI` constant. It points to `https://{site_domain}/{path_to_themes_folder}/themename/dist` by default. To use another source for assets this value can be changed by defining the constant for example in the `wp-config.php` file with a custom URI.
+
+## Asset versioning
+
+The style and script files are automatically enqueued with the current theme version. To bust browser cache on asset updates change the theme version in the `style.css` file comments.
 
 ### Development
 
@@ -43,7 +49,7 @@ Run with the npm script:
 npm run dev/watch
 ```
 
-Run with webpack:
+or run with Webpack:
 
 ```
 webpack (--watch)
@@ -59,7 +65,7 @@ Build _minified_ versions for production with the npm script:
 npm run build
 ```
 
-or with webpack
+or with Webpack:
 
 ```
 webpack -p
@@ -70,6 +76,22 @@ These commands will compile *minified* versions of your assets.
 ## JavaScript development guide
 
 The theme's Webpack config uses [Babel](https://babeljs.io/) to compile [ES6](https://en.wikipedia.org/wiki/ECMAScript#6th_Edition_-_ECMAScript_2015) into [ES5](https://en.wikipedia.org/wiki/ECMAScript#5th_Edition). Thus we use [classes](http://es6-features.org/#ClassDefinition) and other cool features introduced in ES6. See the full list of ES6 features [here](http://es6-features.org/).
+
+### Enable Babel compiling
+
+If you add *npm packages* using ES6 features, remember to include them for the Babel loader in the `webpack.config.js` file!
+
+```
+// List paths to packages using ES6 to enable Babel compiling.
+include: [
+    path.resolve(__dirname, 'assets/scripts'),
+    path.resolve(__dirname, 'node_modules/foundation-sites')
+],
+```
+
+*UglifyJS will most likely produce an error when trying to minify an ES6 script that is not included for the Babel loader while running `webpack -p`!* 
+
+### Theme scripts
 
 The theme's main JS file `theme.js` holds the main theme class. The `Theme` class has runs other theme JS classes automatically on document ready event. To enable autoloading on JS side define your template scripts as follow:
 
@@ -110,8 +132,6 @@ To run all `docReady` functions manually for the current template *(controlled b
 ```
 window.Theme.runDocReady();
 ```
-
-
 
 ##  Contributors
 

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -3,21 +3,22 @@
 */
 
 // Require 3rd party libraries
-require( "babel-polyfill" );
-require( "foundation-sites" );
+require( 'babel-polyfill' );
+// Uncomment to include Foundation scripts.
+require( 'foundation-sites' );
 
 // Add template-specific scripts.
 let templateScripts = {
-    "PageFrontpage": require( __dirname + "/page-frontpage.js" )
+    'PageFrontpage': require( __dirname + '/page-frontpage.js' )
 };
 
 // Add global scripts that have their 'docReady' method run on every page load.
 let globalScripts = {
-    "Common": require( __dirname + "/common.js" )
+    'Common': require( __dirname + '/common.js' )
 };
 
 // Run the theme scripts.
-let Theme = require( __dirname + "/theme.js" );
+let Theme = require( __dirname + '/theme.js' );
 Theme = new Theme( templateScripts, globalScripts );
 
 // Export for global usage.
@@ -27,4 +28,4 @@ window.Theme = Theme;
 * require main style file here for concatenation
 */
 
-require( __dirname + "/../styles/main.scss" );
+require( __dirname + '/../styles/main.scss' );

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -5,7 +5,7 @@
 // Require 3rd party libraries
 require( 'babel-polyfill' );
 // Uncomment to include Foundation scripts.
-require( 'foundation-sites' );
+// require( 'foundation-sites' );
 
 // Add template-specific scripts.
 let templateScripts = {

--- a/assets/scripts/theme.js
+++ b/assets/scripts/theme.js
@@ -16,7 +16,7 @@ class Theme {
         this._globalControllers = globalControllers;
 
         // Bind run controllers on document ready.
-        document.addEventListener( "DOMContentLoaded", e => this.runDocReady( e ) );
+        document.addEventListener( 'DOMContentLoaded', e => this.runDocReady( e ) );
     };
 
     /**
@@ -59,10 +59,10 @@ class Theme {
      * @return {object|boolean} The controller class object.
      */
     getController( name ) {
-        if ( typeof this._templateControllers[ name ] !== "undefined" ) {
+        if ( typeof this._templateControllers[ name ] !== 'undefined' ) {
             return this._templateControllers[ name ]
         }
-        else if ( typeof this._globalControllers[ name ] !== "undefined" ) {
+        else if ( typeof this._globalControllers[ name ] !== 'undefined' ) {
             return this._globalControllers[ name ]
         }
         else {

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -6,8 +6,8 @@
 namespace THEMENAME\Setup;
 
 // Define the asset path.
-if ( ! defined( 'ASSET_PATH' ) ) {
-    define( 'ASSET_PATH', \get_template_directory_uri() . '/assets/dist' );
+if ( ! defined( 'ASSET_URI' ) ) {
+    define( 'ASSET_URI', \get_template_directory_uri() . '/assets/dist' );
 }
 
 /**
@@ -37,7 +37,7 @@ function setup() {
     \add_theme_support( 'html5', [ 'caption', 'comment-form', 'comment-list', 'gallery', 'search-form' ] );
     // Use main stylesheet for visual editor
     // To add custom styles edit /assets/styles/layouts/_tinymce.scss
-    \add_editor_style( ASSET_PATH . '/styles/main.css' );
+    \add_editor_style( ASSET_URI . '/styles/main.css' );
 }
 \add_action( 'after_setup_theme', __NAMESPACE__ . '\\setup' );
 
@@ -46,8 +46,8 @@ function setup() {
  */
 function assets() {
     $version    = wp_get_theme()->get( 'Version' );
-    \wp_enqueue_style( 'theme-css', ASSET_PATH . '/main.css', [], $version, 'all' );
-    \wp_enqueue_script( 'theme-js', ASSET_PATH . '/main.js', [ 'jquery' ], $version, true );
+    \wp_enqueue_style( 'theme-css', ASSET_URI . '/main.css', [], $version, 'all' );
+    \wp_enqueue_script( 'theme-js', ASSET_URI . '/main.js', [ 'jquery' ], $version, true );
 }
 
 \add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\assets', 100 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,20 +1,21 @@
-const webpack                 = require("webpack");
-const ExtractTextPlugin       = require("extract-text-webpack-plugin");
-const autoprefixer            = require("autoprefixer");
-const autoprefixerBrowsers    = ["> 1%", "last 2 versions", "Firefox ESR", "Opera 12.1"];
+const webpack                 = require('webpack');
+const ExtractTextPlugin       = require('extract-text-webpack-plugin');
+const autoprefixer            = require('autoprefixer');
+const autoprefixerBrowsers    = ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1'];
+const path                    = require( 'path' ); // This resolves into the absolute path of the theme root.
 const env                     = process.env.NODE_ENV;
 
 let config = {
     entry: {
-        main: __dirname + "/assets/scripts/main.js"
+        main: __dirname + '/assets/scripts/main.js'
     },
     output: {
-        path: __dirname + "/assets/dist",
-        filename: "[name].js"
+        path: __dirname + '/assets/dist',
+        filename: '[name].js'
     },
     externals: {
         // Set jQuery to be an external resource.
-        "jquery": "jQuery"
+        'jquery': 'jQuery'
     },
     postcss: function () {
         // Enable autoprefixing.
@@ -22,45 +23,50 @@ let config = {
     },
     plugins: [
         // Extract all css into one file.
-        new ExtractTextPlugin("main.css", {
+        new ExtractTextPlugin('main.css', {
             allChunks: true
         }),
         // Provide jQuery instance for all modules.
         new webpack.ProvidePlugin({
-            jQuery: "jquery"
+            jQuery: 'jquery'
         })
     ],
     module: {
         loaders: [
             {
                 test: /\.js$/,
-                loader: "babel-loader",
-                // Skip any files outside of themes scripts.
+                loader: 'babel-loader',
+                // List paths to packages using ES6 to enable Babel compiling.
                 include: [
-                    __dirname + "/assets/scripts",
+                    path.resolve(__dirname, 'assets/scripts'),
+                    path.resolve(__dirname, 'node_modules/foundation-sites')
                 ],
                 query: {
+                    // Do not use the .babelrc configuration file.
                     babelrc: false,
+                    // The loader will cache the results of the loader in node_modules/.cache/babel-loader.
                     cacheDirectory: true,
-                    plugins: ["transform-runtime"],
-                    presets: ["es2015", "stage-0"]
+                    // The 'transform-runtime' plugin tells babel to require the runtime instead of inlining it.
+                    plugins: ['transform-runtime'],
+                    // List enabled ECMAScript feature sets.
+                    presets: ['es2015', 'stage-0']
                 },
             },
             {
                 test: /\.css$/,
-                loader: ExtractTextPlugin.extract("style", "css")
+                loader: ExtractTextPlugin.extract('style', 'css')
             },
             {
                 test: /\.scss$/,
-                loader: ExtractTextPlugin.extract("style-loader", "css!postcss!sass")
+                loader: ExtractTextPlugin.extract('style-loader', 'css!postcss!sass')
             },
             {
                 test: /\.(woff(2)?|eot|ttf|otf)(\?[a-z0-9=\.]+)?$/,
-                loader: "file?name=../fonts/[name].[ext]"
+                loader: 'file?name=../fonts/[name].[ext]'
             },
             {
                 test: /\.(svg|gif|png|jpeg|jpg)(\?[a-z0-9=\.]+)?$/,
-                loader: "file?name=../images/[name].[ext]"
+                loader: 'file?name=../images/[name].[ext]'
             }
         ]
     },
@@ -69,7 +75,7 @@ let config = {
     }
 };
 
-if (env === "production") {
+if (env === 'production') {
     config.plugins.push(
         // Minify for the production environment.
         new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
- Better documentation for `webpack.config.js`.
- Commented out the Foundation scripts, can be uncommented to include.
- Provided an example for how to include ES6 scripts under node modules for Babel compiling.
- JS code style changes.
- Changed the `ASSET_PATH` constant to `ASSET_URI`.