### PR TITLE
Add global click event listener.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Global click event listener to be used with data-cmd and data-ctrl -attributes
+
 ## [1.0.1] - 2017-09-01
 
 ### Changed

--- a/README.MD
+++ b/README.MD
@@ -224,9 +224,18 @@ This **static** function wraps the `querySelector` functions to select a single 
 let element = $1('.my-element', myParentElementObject);
 ```
 
+### Global event listener and data-cmd attributes
+
+Theme class adds global click event listener which you can use by adding data-cmd and data-ctrl attributes
+to your html element, where `data-ctrl` defines the JavaScript controller class and `data-cmd` the method to be called.
+```
+<button data-cmd="doSomething" data-ctrl="MyAwesomeController" />
+```
+
 ##  Contributors
 
 - [devgeniem](https://github.com/devgeniem)
 - [ironland](https://github.com/ironland)
 - [villesiltala](https://github.com/villesiltala)
 - [nomafin](https://github.com/Nomafin)
+- [petrimj](https://github.com/petrimj)

--- a/assets/scripts/theme.js
+++ b/assets/scripts/theme.js
@@ -194,18 +194,16 @@ class Theme {
      * in defined controller, if exists.
      */
     addGlobalListener() {
-        const that = this;
-
-        jQuery(document).on('click', function(e) {
-            const captured = that.findCmdAttribute(e.target);
+        jQuery(document).on('click', e => {
+            const captured = this.findCmdAttribute(e.target);
 
             if (captured) {
                 let command = captured.cmd.cid;
                 let controllerName = captured.cmd.ctrl;
-                let controllerInstance = that.getController(controllerName);
+                let controllerInstance = this.getController(controllerName);
 
                 if ( typeof controllerInstance[command] === 'function' ) {        
-                    that.Common.stop(e);
+                    this.Common.stop(e);
                     controllerInstance[command].call(controllerInstance, e);
                 }
             }

--- a/assets/scripts/theme.js
+++ b/assets/scripts/theme.js
@@ -136,7 +136,7 @@ class Theme {
             }
         }
 
-        this.addGlobalListener();
+        this.addDataCmdListener();
     }
 
     /**
@@ -182,9 +182,13 @@ class Theme {
             element = element.parentNode;
         }
 
-        return {
-            cmd : foundAttr,
-            link : foundLink
+        if(foundAttr) {
+            return {
+                cmd : foundAttr,
+                link : foundLink
+            };
+        } else {
+            return false;
         }
     }
 
@@ -193,7 +197,7 @@ class Theme {
      * has data-cmd and data-ctrl attributes, call the corresponding method 
      * in defined controller, if exists.
      */
-    addGlobalListener() {
+    addDataCmdListener() {
         jQuery(document).on('click', e => {
             const captured = this.findCmdAttribute(e.target);
 
@@ -202,7 +206,7 @@ class Theme {
                 let controllerName = captured.cmd.ctrl;
                 let controllerInstance = this.getController(controllerName);
 
-                if ( typeof controllerInstance[command] === 'function' ) {        
+                if ( controllerInstance && typeof controllerInstance[command] === 'function' ) {        
                     this.Common.stop(e);
                     controllerInstance[command].call(controllerInstance, e);
                 }


### PR DESCRIPTION
Lisätään globaali tapahtumakuuntelija, jota käytetään html-elementtien data-cmd ja data-ctrl -attribuuttien kautta. "findCmdAttribute(element)" -funktio käy läpi klikatun elementin ylemmät nodet cmd-attribuuttien varalta.