### PR TITLE
Disable automatic html encoding from header.dust <title> tag.

### DIFF
--- a/partials/shared/header.dust
+++ b/partials/shared/header.dust
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>{WP.title}</title>
+    <title>{WP.title|s}</title>
     {! Style container for removing outline focus in an accessible manner !}
     {! Check out: https://www.paciellogroup.com/blog/2012/04/how-to-remove-css-outlines-in-an-accessible-manner/ !}
     <style id="accessible-outline"></style>


### PR DESCRIPTION
Disable automatic html encoding from header.dust <title> tag.

Title could contain special characters.